### PR TITLE
Fix pgbouncer version check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - include: install.yml
 
 - name: PGBouncer | Check pgbouncer version
-  shell: pgbouncer --version | awk '{if($2 == "version") print $3; else print $2 }'
+  shell: pgbouncer --version | grep -i pgbouncer | awk '{if($2 == "version") print $3; else print $2 }'
   register: pgbouncer_installed_version
   tags:
     - deploy


### PR DESCRIPTION
Current output
```bash
$ pgbouncer --version
PgBouncer 1.15.0
libevent 2.0.21-stable
adns: evdns2
tls: OpenSSL 1.0.2g  1 Mar 2016
```
previous output
```bash
$ pgbouncer --version 
pgbouncer version 1.9.0
```